### PR TITLE
Fix sticky footer layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,6 +40,10 @@ html {
 ::-webkit-scrollbar-thumb { background-color: var(--hacker-cyan-dim); }
 ::-webkit-scrollbar-thumb:hover { background-color: var(--hacker-cyan-medium); }
 
+html, body {
+  height: 100%;
+}
+
 body {
   font-family: 'Inter', sans-serif;
   color: black;
@@ -48,6 +52,9 @@ body {
   padding-top: 70px; /* Assuming fixed navbar height of approx 70px. Adjust if navbar height changes. */
   word-wrap: break-word;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 /* --- Global Heading Adjustments for Mobile First --- */
@@ -190,6 +197,7 @@ h6 { font-size: var(--h6-font-size-mobile); }
   padding: 2rem 1rem; /* Padding for mobile */
   font-size: var(--font-size-sm);
   text-align: center; /* Center content on mobile */
+  margin-top: auto; /* Stick footer to page bottom */
 }
 .footer .list-inline-item {
     margin-bottom: 0.5rem; /* Space when icons stack/wrap */


### PR DESCRIPTION
## Summary
- keep footer pinned to the bottom of the page by using a flex layout on the body
- ensure the footer element has `margin-top: auto`
- define `html, body` height to support sticky footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ac37f5eb8832d9f6eadf3721bc3ca