### PR TITLE
Improve blog styling and fix markdown typos

### DIFF
--- a/DP-300-2.md
+++ b/DP-300-2.md
@@ -21,7 +21,7 @@ Inside the monitoring tab in the insight.
 
 ## Intelligent Insights: Gives hardware and software insights (sql server itself)
 
-Performance overview, performance recommendations, query perfromance insights. and diagnostic settings. 
+Performance overview, performance recommendations, query performance insights, and diagnostic settings.
 
 
 ## Storage Configuration
@@ -32,7 +32,7 @@ Performance overview, performance recommendations, query perfromance insights. a
 * Azure DISK: accessed only from within the VM, best for sql server data and log files.
 
 #### AZURE DISK
-* Standard HDD for infrequest access data
+* Standard HDD for infrequent access data
 * Standard SSD: Low traffic db and test and dev
 * Premium SSD: prod db, read caching
 * Ultra disk: submillisecond.

--- a/DP-300_1.md
+++ b/DP-300_1.md
@@ -8,7 +8,7 @@
 ## Pricing Models.
 * General Purpose: vCore pricing
 * Large scale: Hyperscale storage.
-* Serverless Tiers: Scaling resouces, like elastic pool. DTUs
+* Serverless Tiers: Scaling resources, like elastic pools. DTUs
 
 
 ### MYSQL/MariaDB: Fully managed database server. Single and Service
@@ -24,7 +24,7 @@
 &rarr; BYOL and Pay as you go.
 
 1. **A-series**: low-vol developement or test databases. 
-2. **B-Series**: Like A-series workloads with the ability to brust perfromance temporarily.
+2. **B-Series**: Like A-series workloads with the ability to burst performance temporarily.
 3. **D-Series**: Faster processor
 4. **E-Series**: Memory optimised for in-memory analytics
 5. **F-Series**: web server and gaming application
@@ -36,10 +36,10 @@
 &rarr; AZ within regions are different physical locations.
 
 ### 2. Availability Sets
-&rarr; Availability set are located within the same location but in different servers still might sare resource like cooler and all.
+&rarr; Availability sets are located within the same location but on different servers and might share resources like cooling, etc.
 
 ### Always on Availability Groups
-* Group tow or more sql server instance together, one is "primary replication" and all other are "secondary replicas".
+* Group two or more SQL Server instances together, one is the "primary replica" and the others are "secondary replicas".
 * Txn are first commited to primary replica and synchronously or asynchronously to secondary replicas.
 * Secondary can be primary.
 ---

--- a/Dp-300-3.md
+++ b/Dp-300-3.md
@@ -31,8 +31,8 @@
 
 ### Auto Failover group
 * region redundant replicas.
-* Listner services are used to route application
-* R/W and read-only listner to send to approp replica.
+* Listener services are used to route applications.
+* R/W and read-only listeners send traffic to the appropriate replica.
 * During an outage, traffic is automatically routed to available servers in an Auto Failover Group.
 (Azure sql database and managed instance.)
 

--- a/Only_HA.md
+++ b/Only_HA.md
@@ -1,11 +1,11 @@
 # Only HA and DR solutions in SQL SERVER
 ## Replication for HA
-Publications, distributer, subscriptions
+Publications, distributor, subscriptions
 
-Pulisher-Distributer Architecture: 
+Publisher-Distributor Architecture:
 
 1. Snapshot Publication: Send the snapshot of published data to subscribers at scheduled intervals.
-2. The Transactional: Publisher streams txn to subscripbers after they receive an initial snapshot of the published data.
+2. The Transactional: Publisher streams transactions to subscribers after they receive an initial snapshot of the published data.
 3. Peer-to-peer: Multi-master replication. The publisher streams txn to all the peers in topology. All the peers can read and write changes and changes are propagated to all the nodes. 
 4. Merge Publication: update the published data independently after the subscribers receive an initial snapshot of the published data. Changes are merged periodically. Compact edition can only subscribe to merge. There should always be the publisher. Non-realtime.
 

--- a/blog.html
+++ b/blog.html
@@ -19,7 +19,7 @@
 <body class="font-sans">
   <div id="navbar-placeholder"></div>
   <div class="container my-5">
-    <div id="content"></div>
+    <div id="content" class="markdown-body"></div>
   </div>
   <div id="footer-placeholder"></div>
 

--- a/css/style.css
+++ b/css/style.css
@@ -427,3 +427,25 @@ h6 { font-size: var(--h6-font-size-mobile); }
 
   .scroll-down { bottom: 40px; } /* Original */
 }
+
+/* ------- Blog Content ------- */
+#content {
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+#content img {
+  max-width: 100%;
+  height: auto;
+}
+#content pre {
+  overflow-x: auto;
+  background-color: #f8f9fa;
+  padding: 1rem;
+  border-radius: 6px;
+}
+#content h1, #content h2, #content h3,
+#content h4, #content h5, #content h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- clean up blog content container with responsive CSS
- tweak blog page markup to use `markdown-body` class
- fix typos in Azure migration notes
- fix typos in optimization notes
- fix wording in HA/DR notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686498049804832d8360cbaab822b24c