### PR TITLE
Add all markdown posts to blog list

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg fixed-top nav-blur navbar-dark py-3">
     <div class="container">
-      <a class="navbar-brand text-white font-bold" href="#">
+      <a class="navbar-brand text-white font-bold" href="index.html">
         <span class="text-teal-300">A</span>nish <span class="text-teal-300">K</span>arki
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/js/blogs.js
+++ b/js/blogs.js
@@ -11,9 +11,59 @@ document.addEventListener('DOMContentLoaded', () => {
       category: 'Azure'
     },
     {
-      title: 'Only HA and DR solutions in SQL SERVER',
+      title: 'High Availability and Disaster Recovery',
+      file: 'Dp-300-3.md',
+      category: 'High Availability'
+    },
+    {
+      title: 'Only HA and DR solutions in SQL Server',
       file: 'Only_HA.md',
+      category: 'High Availability'
+    },
+    {
+      title: 'The modern SQL Server DBA - HandBook',
+      file: 'DatabaseAdmin/Interviewprep1.md',
       category: 'SQL Server'
+    },
+    {
+      title: 'Mail is vital',
+      file: 'DatabaseAdmin/AllaboutAvailabiilty.md',
+      category: 'SQL Server'
+    },
+    {
+      title: 'SQL Server architecture',
+      file: 'DatabaseAdmin/interviewprep2.md',
+      category: 'SQL Server'
+    },
+    {
+      title: 'Interview Prep Day 3 - SQL Server',
+      file: 'DatabaseAdmin/interviewprep3.md',
+      category: 'SQL Server'
+    },
+    {
+      title: 'All Scenario Based',
+      file: 'DatabaseAdmin/interviewprep4.md',
+      category: 'SQL Server'
+    },
+    {
+      title: 'Database Backups',
+      file: 'DatabaseAdmin/backupsinfo.md',
+      category: 'Backup'
+    },
+    {
+      title: 'Query Examples',
+      file: 'DatabaseAdmin/Queries.md',
+      category: 'Queries'
+    },
+    {
+      title: 'Plan Change Simulation',
+      file: 'DatabaseAdmin/SimulatingPlanchange.md',
+      category: 'SQL Server'
+    },
+    {
+      title: 'Installing Always on Availability Group in Docker',
+      file: 'DatabaseAdmin/setup_ag_docker.md',
+      category: 'Docker'
     }
   ];
 


### PR DESCRIPTION
## Summary
- add all markdown articles to the blog listing with categories
- fix navbar link so home button goes back to `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68649c6be054832daf69cc545dcdaeee